### PR TITLE
Fixed release for resin-wifi-connect

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -33,7 +33,7 @@ RUN apt-get update && apt-get install -yq --no-install-recommends \
 # Install node
 ENV NODE_VERSION 6.9.1
 RUN curl -SLO "http://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-armv6l.tar.gz" && \
-    echo "0b30184fe98bd22b859db7f4cbaa56ecc04f7f526313c8da42315d89fabe23b2  node-v6.9.1-linux-armv6l.tar.gz" | sha256sum -c - && \
+    echo "0b30184fe98bd22b859db7f4cbaa56ecc04f7f526313c8da42315d89fabe23b2  node-v$NODE_VERSION-linux-armv6l.tar.gz" | sha256sum -c - && \
     tar -xzf "node-v$NODE_VERSION-linux-armv6l.tar.gz" -C /usr/local --strip-components=1 && \
     rm "node-v$NODE_VERSION-linux-armv6l.tar.gz" && \
     npm config set unsafe-perm true -g --unsafe-perm && \

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -40,7 +40,10 @@ RUN curl -SLO "http://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-a
     rm -rf /tmp/*
 
 # Install resin-wifi-connect
-RUN git clone https://github.com/resin-io/resin-wifi-connect.git && \
+ENV RESIN_WIFI_CONNECT_VERSION 2.0.5
+RUN curl -SL "https://github.com/resin-io/resin-wifi-connect/archive/v$RESIN_WIFI_CONNECT_VERSION.tar.gz" \
+    | tar xzC /usr/src/app/ && \
+    mv resin-wifi-connect-$RESIN_WIFI_CONNECT_VERSION resin-wifi-connect && \
     cd resin-wifi-connect && \
     JOBS=MAX npm install --unsafe-perm --production && \
     npm cache clean && \


### PR DESCRIPTION
As resin-wifi-connect-example will be used and copied by many, it's better to have a fixed release for resin-wifi-connect.

I got troubles when rwc went from 1ish to 2.0.0, I would like to prevent those troubles to happen to others.